### PR TITLE
Fix typo in setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ npm install
      - [Reference setting](./public/pinecone-setup.png)
 
 ```sh
-cp .env.example .env.
+cp .env.example .env
 ```
 
 5. Run the project


### PR DESCRIPTION
The `.env.` file is not working.
Probably `.env` is correct. (It will work with that name).