### PR TITLE
[update] Translator module

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,5 +19,5 @@ NEXT_PUBLIC_USE_USER_API_KEY="false"
 
 # if you want to use the auto-translation feature, set the following variables
 # and npm run translate
-TRANSLATOR_SERVICE="google"
-OPENAI_TRANSLATION_METHOD="chat"
+TRANSLATOR_SERVICE="google" # possible values: "google", "openai"
+OPENAI_TRANSLATION_METHOD="chat" # possible values: "chat", "text" (NOTE: only need if the TRANSLATOR_SERVICE is "openai")

--- a/translator.cjs
+++ b/translator.cjs
@@ -152,13 +152,21 @@ class Translator {
                     },
                   );
                 } else {
-                  this.writeTranslationFile(targetLangFilePath, key, null);
+                  this.writeTranslationFile(
+                    targetLangFilePath,
+                    key,
+                    'MISSING_TRANSLATION',
+                  );
                   rl.close();
                 }
               },
             );
           } else {
-            this.writeTranslationFile(targetLangFilePath, key, null);
+            this.writeTranslationFile(
+              targetLangFilePath,
+              key,
+              'MISSING_TRANSLATION',
+            );
           }
         }
       }),

--- a/translator.cjs
+++ b/translator.cjs
@@ -1,7 +1,6 @@
 require('dotenv').config();
 const fs = require('fs');
 const path = require('path');
-const { Configuration, OpenAIApi } = require('openai');
 
 class Translator {
   constructor(srcLang, targetLang, transService, settings = {}) {
@@ -21,6 +20,7 @@ class Translator {
       this.translatorService === 'openai' &&
       process.env.OPENAI_API_KEY !== ''
     ) {
+    const { Configuration, OpenAIApi } = require('openai');
       this.configuration = new Configuration({
         apiKey: process.env.OPENAI_API_KEY,
       });
@@ -50,8 +50,6 @@ class Translator {
 
   extractKeyNamespacePairs(filePath) {
     let fileContent = fs.readFileSync(filePath, 'utf8');
-    // const regex =
-    //      /(?:translate|i18n\?\.t|t)\(\s*?['"]([^'"]+)['"](?:\s*?,\s*?['"]([^'"]+)['"])(?:\s?,\s*?['"]([^'"]+)['"])?\)/g; // Working
 
     const regex =
       /(?:translate\(|i18n\?\.t\(|t\()['"](?!(?:\\n|a)['"])([^'"]+)['"](?:\s?,\s?['"]([^'"]+)['"])?(?:,\s?['"]([^'"]+)['"])?\)/g;
@@ -128,6 +126,7 @@ class Translator {
         const sourceTranslationValue = this.getTranslationValue(
           srcLangFilePath,
           key,
+          namespace
         );
         if (sourceTranslationValue !== '') {
           const translatedValue = await this.translateText(
@@ -146,7 +145,7 @@ class Translator {
                       this.writeTranslationFile(
                         targetLangFilePath,
                         key,
-                        enteredTranslation,
+                        enteredTranslation
                       );
                       rl.close();
                     },
@@ -234,16 +233,29 @@ class Translator {
     }
   }
 
-  getTranslationValue(filePath, key) {
-    if (!fs.existsSync(filePath)) {
-      return '';
-    }
-    const content = fs.readFileSync(filePath, 'utf8');
-    const translations = JSON.parse(content);
-    return translations[key] || '';
+  
+getTranslationValue(filePath, key, namespace) {
+  if (!fs.existsSync(filePath)) {
+    return '';
   }
+  const content = fs.readFileSync(filePath, 'utf8');
+  const translations = JSON.parse(content);
+  const keys = key.split('.');
+  let value = translations;
+  for (const k of keys) {
+    if (value.hasOwnProperty(k)) {
+      value = value[k];
+    } else {
+      value = '';
+      break;
+    }
+  }
+  return value;
+}
 
-async translateText(sourceTranslationValue) {
+
+
+  async translateText(sourceTranslationValue) {
     if (this.translatorService === 'google') {
       return await this.GoogleTranslate(
         this.srcLang,
@@ -254,8 +266,8 @@ async translateText(sourceTranslationValue) {
       this.translatorService === 'openai' &&
       this.openaiTranslationMethod === 'chat'
     ) {
-      const TRANSLATE_PROMPT = `Translate the ${sourceTranslationValue} text using the ${this.targetLang} language code then respond only with the translated text.`;
-      return await this.translateViaChatCompletion(TRANSLATE_PROMPT);
+      const USER_PROMPT = `What you have to translate is: "${sourceTranslationValue}"\nThe language code you have to use is: ${this.targetLang}`;
+      return await this.translateViaChatCompletion(USER_PROMPT);
     } else if (
       this.translatorService === 'openai' &&
       this.openaiTranslationMethod === 'text'
@@ -298,6 +310,76 @@ async translateText(sourceTranslationValue) {
     }
   }
 
+  async manageFolders() {
+  const allowedLocales = await this.detectAllowedLocales();
+  // Perform folder management operations based on the allowedLocales
+}
+
+async detectAllowedLocales() {
+  // Detect the allowed locales by analyzing the existing translation files
+  // and return an array of detected locales
+  return ["en", "de", "hu", "ja", "ko", "pt"]; // test
+}
+
+async translateProject() {
+  const allowedLocales = await this.detectAllowedLocales();
+  const sourceTranslationDir = path.join(
+    __dirname,
+    'public',
+    'locales',
+    'translation'
+  );
+
+  if (fs.existsSync(sourceTranslationDir)) {
+    const files = fs.readdirSync(sourceTranslationDir);
+    files.forEach(async (file) => {
+      const srcFilePath = path.join(sourceTranslationDir, file);
+      const stats = fs.statSync(srcFilePath);
+
+      if (stats.isFile()) {
+        const content = fs.readFileSync(srcFilePath, 'utf8');
+        const translations = JSON.parse(content);
+
+        for (const locale of allowedLocales) {
+          const targetDir = path.join(
+            __dirname,
+            'public',
+            'locales',
+            locale,
+            'translation'
+          );
+
+          if (!fs.existsSync(targetDir)) {
+            fs.mkdirSync(targetDir, { recursive: true });
+          }
+
+          const targetFilePath = path.join(targetDir, file);
+          const targetContent = await this.translateJSON(translations, locale);
+          fs.writeFileSync(targetFilePath, targetContent, 'utf8');
+        }
+      }
+    });
+  }
+}
+
+async translateJSON(json, locale) {
+  const translatedJson = {};
+
+  await Promise.all(
+    Object.entries(json).map(async ([key, value]) => {
+      if (typeof value === 'object') {
+        translatedJson[key] = await this.translateJSON(value, locale);
+      } else {
+        this.targetLang = locale;
+        const translatedValue = await this.translateText(value);
+        translatedJson[key] = translatedValue;
+      }
+    })
+  );
+
+  return JSON.stringify(translatedJson, null, 2);
+}
+
   // Services
   // GoogleTranslate
   GoogleTranslate = async (
@@ -329,11 +411,13 @@ async translateText(sourceTranslationValue) {
   };
 
   // Translate via OpenAI ChatCompletion
-  translateViaChatCompletion = async (TRANSLATE_PROMPT) => {
+  translateViaChatCompletion = async (USER_PROMPT) => {
+    const MASTER_PROMPT = "You are a professional translator named AT-i18n. You have to wait for the user to provide the translatable text and the target language's code. You have to respond ONLY with the translated text."
     const translationResult = await this.openai.createChatCompletion({
       model: 'gpt-3.5-turbo',
       temperature: 1,
-      messages: [{ role: 'user', content: TRANSLATE_PROMPT }],
+      messages: [ {role: 'system', content: MASTER_PROMPT},
+        { role: 'user', content: USER_PROMPT }],
     });
     return translationResult.data.choices[0].message.content.replace(
       /^['",`]+|['",`]+$/g,
@@ -356,13 +440,15 @@ async translateText(sourceTranslationValue) {
       .split('\n\n')[1]
       .replace(/^['",`]+|['",`]+$/g, '');
   };
-
+  
+  
   // main run
   async run(srcDirectory) {
     this.collectKeyNamespacePairs(srcDirectory);
     await this.translateAndWriteFiles();
     console.log('Translation files generated successfully.');
   }
+
 }
 
 const readline = require('readline');

--- a/translator.cjs
+++ b/translator.cjs
@@ -243,7 +243,7 @@ class Translator {
     return translations[key] || '';
   }
 
-  async translateText(sourceTranslationValue) {
+async translateText(sourceTranslationValue) {
     if (this.translatorService === 'google') {
       return await this.GoogleTranslate(
         this.srcLang,
@@ -254,12 +254,14 @@ class Translator {
       this.translatorService === 'openai' &&
       this.openaiTranslationMethod === 'chat'
     ) {
-      return await this.translateViaChatCompletion(sourceTranslationValue);
+      const TRANSLATE_PROMPT = `Translate the ${sourceTranslationValue} text using the ${this.targetLang} language code then respond only with the translated text.`;
+      return await this.translateViaChatCompletion(TRANSLATE_PROMPT);
     } else if (
       this.translatorService === 'openai' &&
       this.openaiTranslationMethod === 'text'
     ) {
-      return await this.translateViaCompletion(sourceTranslationValue);
+      const TRANSLATE_PROMPT = `Translate the ${sourceTranslationValue} text using the ${this.targetLang} language code then respond only with the translated text.`;
+      return await this.translateViaTextCompletion(TRANSLATE_PROMPT);
     } else {
       return console.log('No translator service selected.');
     }


### PR DESCRIPTION
I have already created a repository for this
[AutoTranslator-i18n](https://github.com/Cs4K1Sr4C/AutoTranslator-i18n)

**Updated REGEX, extractor and translator mechanisms**
[Visual REGEX](https://regexper.com/#%2F%28%3F%3Atranslate%5C%28%7Ci18n%5C%3F%5C.t%5C%28%7Ct%5C%28%29%5B'%22%5D%28%3F!%28%3F%3A%5C%5Cn%7Ca%29%5B'%22%5D%29%28%5B%5E'%22%5D%2B%29%5B'%22%5D%28%3F%3A%5Cs%3F%2C%5Cs%3F%5B'%22%5D%28%5B%5E'%22%5D%2B%29%5B'%22%5D%29%3F%28%3F%3A%2C%5Cs%3F%5B'%22%5D%28%5B%5E'%22%5D%2B%29%5B'%22%5D%29%3F%5C%29%2Fg)

Accepts the following functions:
- ```i18n?.t```
- ```t```
- ```translate```

Accepts the ```'``` and ```"``` in the functions for the ```key, default_english_text, namespace``` values.
 
Collects and extracts the following syntaxes:
- ```translate|t|i18n?.t("{key}")``` - default namespace "common"
- ```translate|t|i18n?.t("{key}", "{namespace}")```
- ```translate|t|i18n?.t("{key}", "{default_english_text"}, "{namespace}")```

If the key or the value is not found in the source (```/public/locales/en/{namespace}.json```) translation file then the script will create the ```"{key}": "MISSING_TRANSLATION"``` key/value pair.