### PR TITLE
Update constants.json

### DIFF
--- a/public/locales/de/constants.json
+++ b/public/locales/de/constants.json
@@ -4,7 +4,7 @@
   "FEEDBACK_SUBMITTED_TOAST": "Danke schön! ",
   "GPT_4_WARNING": "🚨 DIE VERWENDUNG VON GPT-4 POTENZIELL TEUER IST, ÜBERWACHEN SIE IHRE KOSTEN!",
   "INFINITY": "Unendlichkeit",
-  "LIGHT": "Licht",
+  "LIGHT": "Hell",
   "SYSTEM": "System",
   "UNTIL_ALL_TASKS_COMPLETED": "Bis alle Aufgaben abgeschlossen sind"
 }


### PR DESCRIPTION
Correct translation for Darkmode. Light means light (Licht) ("turn the lights on"), but is not the correct translation in the context of Darkmode. Better English translation would be "bright" and "dark".