### PR TITLE
Remove a mod agent from the menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ This is a port of [babyagi](https://github.com/yoheinakajima/babyagi) with [Lang
 - [x] Improv UX for task creation (only BabyCatAGI🐱 & Client request)
 - [x] Notification that all tasks have been completed. 🔔
 - [x] Display the current task and task list. 📌
-- [x] Added our experimental agent. [🧪 BabyCatAGI (mod)]: Generate search queries, Check the sufficiency of task results.
 - [x] Collapsible Sidebar ⏩️
 - [ ] Other LLM models support
 

--- a/src/components/Agent/Agent.tsx
+++ b/src/components/Agent/Agent.tsx
@@ -27,7 +27,6 @@ import { AgentMessageFooter } from './AgentMessageFooter';
 import axios from 'axios';
 import { taskCompletedNotification } from '@/utils/notification';
 import { MessageSummaryCard } from './MessageSummaryCard';
-import { BUIExecuter } from '@/agents/babyagiui-mod/executer';
 import { useTranslation } from 'next-i18next';
 
 export const Agent: FC = () => {
@@ -41,9 +40,9 @@ export const Agent: FC = () => {
   const [agentStatus, setAgentStatus] = useState<AgentStatus>({
     type: 'ready',
   });
-  const [agent, setAgent] = useState<
-    BabyAGI | BabyBeeAGI | BabyCatAGI | BUIExecuter | null
-  >(null);
+  const [agent, setAgent] = useState<BabyAGI | BabyBeeAGI | BabyCatAGI | null>(
+    null,
+  );
   const [selectedAgent, setSelectedAgent] = useState<SelectItem>(AGENT[0]);
   const { i18n } = useTranslation();
   const [language, setLanguage] = useState(i18n.language);
@@ -195,17 +194,6 @@ export const Agent: FC = () => {
         break;
       case 'babycatagi':
         agent = new BabyCatAGI(
-          objective,
-          model.id,
-          messageHandler,
-          setAgentStatus,
-          cancelHandle,
-          language,
-          verbose,
-        );
-        break;
-      case 'bui-mod-1':
-        agent = new BUIExecuter(
           objective,
           model.id,
           messageHandler,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -43,14 +43,7 @@ export const AGENT = [
     name: 'BabyCatAGI',
     icon: '🐱',
     message: '🤖/🔎+📄',
-    badge: 'ORIGINAL',
-  },
-  {
-    id: 'bui-mod-1',
-    name: 'BabyCatAGI (mod)',
-    icon: '🧪',
-    message: '🤖/🔎+📄',
-    badge: 'EXPERIMENTAL',
+    badge: 'LATEST',
   },
   {
     id: 'babybeeagi',


### PR DESCRIPTION
Providing a Mod version is out of the scope of the UI project, so we have removed it from the menu.
The base files for the mods are left so developers can extend them.