### PR TITLE
Display markdown table correctly

### DIFF
--- a/src/components/Agent/AgentTask.tsx
+++ b/src/components/Agent/AgentTask.tsx
@@ -2,6 +2,7 @@ import { MessageBlock } from '@/types';
 import { FC } from 'react';
 import { AgentCollapsible } from './AgentCollapsible';
 import remarkGfm from 'remark-gfm';
+import { AgentResult } from './AgentResult';
 import { ReactMarkdown } from 'react-markdown/lib/react-markdown';
 import { AgentLabelBlock } from './AgentLabelBlock';
 import { AgentTaskStatus } from './AgentTastStatus';


### PR DESCRIPTION
Use remark-gfm plugins https://remarkjs.github.io/react-markdown/ to display tables in markdown correctly. Currently the tables markdown are displayed as normal "mangled" text ( `| a | b  | c|`)