### PR TITLE
Update BabyElfAGI to use GPT-4 for task creation

### DIFF
--- a/src/agents/babyelfagi/executer.ts
+++ b/src/agents/babyelfagi/executer.ts
@@ -50,7 +50,7 @@ export class BabyElfAGI extends AgentExecuter {
     await this.taskRegistry.createTaskList(
       this.objective,
       skillDescriptions,
-      this.modelName,
+      'gpt-4', // Culletly using GPT-4
       this.messageCallback,
       this.abortController,
       this.language,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -38,7 +38,7 @@ export const AGENT = [
     id: 'babyelfagi',
     name: 'BabyElfAGI',
     icon: '🧝',
-    message: '',
+    message: '(Currently using GPT-4 for task creation)',
     badge: 'BETA',
   },
   {


### PR DESCRIPTION
There may be cases where tasks cannot be completed properly when using gpt-3.5-turbo as the skill selection may not be appropriate. Therefore, we will use gpt-4 regardless of the model selection until adjustments can be made.